### PR TITLE
Add tests for dispatch with arguments

### DIFF
--- a/src/stateMachine.ts
+++ b/src/stateMachine.ts
@@ -57,7 +57,7 @@ export class StateMachine<STATE, EVENT> {
             me.current = tran.toState;
             if (tran.cb) {
               try {
-                tran.cb(args)
+                tran.cb(...args)
                   .then(resolve)
                   .catch(reject);
               } catch (e) {


### PR DESCRIPTION
Hello. I noticed your FSM implementation supports arguments on transitions, but the lack of a spread operator when calling a callback means the callbacks always got an array instead of the expected value. This PR fixes that and includes tests for it.